### PR TITLE
feat: Helm chart for deploying Satisfactory

### DIFF
--- a/charts/satisfactory/.helmignore
+++ b/charts/satisfactory/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/satisfactory/Chart.yaml
+++ b/charts/satisfactory/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: satisfactory
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.2.4"

--- a/charts/satisfactory/README.md
+++ b/charts/satisfactory/README.md
@@ -1,0 +1,23 @@
+# satisfactory
+ Helm chart for deploying a Satisfactory server in Kubernetes. This chart can be installed without modification to deploy a satisfactory server using the defaults specified in the [wolveix/satisfactory-server](https://hub.docker.com/r/wolveix/satisfactory-server) image.
+
+# Parameters
+
+| Parameter               |  Default  | Function                                            |
+| ----------------------- | :-------: | --------------------------------------------------- |
+| `autopause`             |   `true`  | pause game when no player is connected              |
+| `autosaveInterval`      |   `300`   | autosave interval in seconds                        |
+| `autosaveNum`           |    `3`    | number of rotating autosave files                   |
+| `autosaveOnDisconnect`  |   `true`  | autosave when last player disconnects               |
+| `crashReport`           |   `true`  | automatic crash reporting                           |
+| `debug`                 |  `false`  | for debugging the server                            |
+| `disableSeasonalEvents` |  `false`  | disable the FICSMAS event (you miserable bastard)   |
+| `maxPlayers`            |    `4`    | set the player limit for your server                |
+| `pgid`                  |   `1000`  | set the group ID of the user the server will run as |
+| `puid`                  |   `1000`  | set the user ID of the user the server will run as  |
+| `serverBeaconPort`      |  `15000`  | set the game's beacon port                          |
+| `serverGamePort`        |   `7777`  | set the game's port                                 |
+| `serverIP`              | `0.0.0.0` | set the game's ip (usually not needed)              |
+| `serverQueryPort`       |  `15777`  | set the game's query port                           |
+| `skupUpdate`            |  `false`  | avoid updating the game on container start/restart  |
+| `steamBeta`             |  `false`  | set experimental game version                       |

--- a/charts/satisfactory/templates/_helpers.tpl
+++ b/charts/satisfactory/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "satisfactory.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "satisfactory.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "satisfactory.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "satisfactory.labels" -}}
+helm.sh/chart: {{ include "satisfactory.chart" . }}
+{{ include "satisfactory.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "satisfactory.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "satisfactory.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "satisfactory.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "satisfactory.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/satisfactory/templates/configmap.yaml
+++ b/charts/satisfactory/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "satisfactory.fullname" . }}-env
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+data:
+  AUTOPAUSE: "{{ .Values.satisfactoryOpts.autopause | default true }}"
+  AUTOSAVEINTERVAL: "{{ .Values.satisfactoryOpts.autosaveInterval | default 300 }}"
+  AUTOSAVENUM: "{{ .Values.satisfactoryOpts.autosaveNum | default 3 }}"
+  AUTOSAVEONDISCONNECT: "{{ .Values.satisfactoryOpts.autosaveOnDisconnect | default true }}"
+  CRASHREPORT: "{{ .Values.satisfactoryOpts.crashReport | default true }}"
+  DEBUG: "{{ .Values.satisfactoryOpts.debug | default false }}"
+  DISABLESEASONALEVENTS: "{{ .Values.satisfactoryOpts.disableSeasonalEvents | default false }}"
+  MAXPLAYERS: "{{ .Values.satisfactoryOpts.maxPlayers | default 4 }}"
+  PGID: "{{ .Values.satisfactoryOpts.pgid | default 1000 }}"
+  PUID: "{{ .Values.satisfactoryOpts.puid | default 1000 }}"
+  SERVERBEACONPORT: "{{ .Values.satisfactoryOpts.serverBeaconPort | default 15000 }}"
+  SERVERGAMEPORT: "{{ .Values.satisfactoryOpts.serverGamePort | default 7777 }}"
+  SERVERIP: "{{ .Values.satisfactoryOpts.serverIP | default "0.0.0.0" }}"
+  SERVERQUERYPORT: "{{ .Values.satisfactoryOpts.serverQueryPort | default 15777 }}"
+  SKIPUPDATE: "{{ .Values.satisfactoryOpts.skipUpdate | default false }}"
+  STEAMBETA: "{{ .Values.satisfactoryOpts.steamBeta | default false }}"

--- a/charts/satisfactory/templates/deployment.yaml
+++ b/charts/satisfactory/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "satisfactory.fullname" . }}
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "satisfactory.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "satisfactory.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "satisfactory.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository | default "wolveix/satisfactory-server" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: beacon-port
+              containerPort: {{ .Values.satisfactoryOpts.serverBeaconPort | default 15000 }}
+              protocol: UDP
+            - name: game-port
+              containerPort: {{ .Values.satisfactoryOpts.serverGamePort | default 7777 }}
+              protocol: UDP
+            - name: query-port
+              containerPort: {{ .Values.satisfactoryOpts.serverQueryPort | default 15777 }}
+              protocol: UDP
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "satisfactory.fullname" . }}-env
+            {{- if .Values.envFrom }}
+            {{- toYaml .Values.envFrom | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistentVolumeClaim.enable }}
+            - mountPath: /config
+              name: {{ include "satisfactory.fullname" . }}-pv
+          {{- end }}
+      volumes:
+      {{- if .Values.persistentVolumeClaim.enable }}
+        - name: {{ include "satisfactory.fullname" . }}-pv
+          persistentVolumeClaim:
+            claimName: {{ include "satisfactory.fullname" . }}-pvc
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/satisfactory/templates/pvc.yaml
+++ b/charts/satisfactory/templates/pvc.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.persistentVolumeClaim.enable }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "satisfactory.fullname" . }}-pvc
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+spec:
+    {{- toYaml .Values.persistentVolumeClaim.spec | nindent 4 }}
+{{- end }}

--- a/charts/satisfactory/templates/service.yaml
+++ b/charts/satisfactory/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "satisfactory.fullname" . }}
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- toYaml .Values.service.ports | nindent 4 }}
+  selector:
+    {{- include "satisfactory.selectorLabels" . | nindent 4 }}

--- a/charts/satisfactory/templates/serviceaccount.yaml
+++ b/charts/satisfactory/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "satisfactory.serviceAccountName" . }}
+  labels:
+    {{- include "satisfactory.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/satisfactory/values.yaml
+++ b/charts/satisfactory/values.yaml
@@ -1,0 +1,94 @@
+# Default values for satisfactory.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+satisfactoryOpts:
+  autopause:
+  autosaveInterval: 
+  autosaveNum: 
+  autosaveOnDisconnect: 
+  crashReport:
+  debug:
+  disableSeasonalEvents:
+  maxPlayers:
+  pgid:
+  puid:
+  serverBeaconPort:
+  serverGamePort:
+  serverIP:
+  serverQueryPort:
+  skipUpdate:
+  steamBeta: true
+
+persistentVolumeClaim:
+  enable: true
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+
+image:
+  # Sets Docker image for Satisfactory server, default wolveix/satisfactory-server
+  repository: ""
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+env: []
+envFrom: []
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "satisfactory-sa"
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# Ensure targetPort matches port config in satisfactoryOpts
+service:
+  type: LoadBalancer
+  ports:
+  - name: beacon-port
+    port: 15000
+    targetPort: 15000
+    protocol: UDP
+  - name: game-port
+    port: 7777
+    targetPort: 7777
+    protocol: UDP
+  - name: query-port
+    port: 15777
+    targetPort: 15777
+    protocol: UDP
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR adds a Helm chart to this repository that will deploy a Satisfactory server based on the [wolveix/satisfactory-server](https://hub.docker.com/r/wolveix/satisfactory-server) image.